### PR TITLE
Change runtime class name

### DIFF
--- a/k8s
+++ b/k8s
@@ -139,7 +139,7 @@ spec:
       labels:
         app: $NAME
     spec:
-      runtimeClassName: wasmtime-spin-v1
+      runtimeClassName: wasmtime-spin
       containers:
         - name: $NAME
           image: $NAMESPACE/$NAME:$VERSION


### PR DESCRIPTION
The plugin fails to deploy a Spin app when using the plugin with this [`runtime.yaml`](https://github.com/deislabs/containerd-wasm-shims/blob/main/deployments/workloads/runtime.yaml), which is the one that is installed in the [`containerd-wasm-shims` quickstart](https://github.com/deislabs/containerd-wasm-shims/blob/main/containerd-shim-spin-v1/quickstart.md) as follows:

```bash
kubectl apply -f https://raw.githubusercontent.com/deislabs/containerd-wasm-shims/main/deployments/workloads/runtime.yaml
```

This matches the RuntimeClass name with the name of the one deployed in the quickstart. 