### PR TITLE
fix(k8s): use spec.ingressClassName

### DIFF
--- a/k8s
+++ b/k8s
@@ -161,8 +161,8 @@ metadata:
   name: $NAME
   annotations:
     ingress.kubernetes.io/ssl-redirect: "false"
-    kubernetes.io/ingress.class: traefik
 spec:
+  ingressClassName: traefik
   rules:
     - http:
         paths:


### PR DESCRIPTION
Addresses the deprecation warning below per https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

```
$ spin k8s deploy
deployment.apps/http-rust created
service/http-rust created
Warning: annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
ingress.networking.k8s.io/http-rust created
```